### PR TITLE
Mark instance methods as 'final' for non-final subclasses of JavaScriptObject

### DIFF
--- a/src/main/java/com/gwidgets/api/leaflet/events/DragEndEvent.java
+++ b/src/main/java/com/gwidgets/api/leaflet/events/DragEndEvent.java
@@ -31,7 +31,7 @@ public class DragEndEvent extends Event {
 	 *
 	 * @return the distance
 	 */
-	public native double getDistance()/*-{
+	public final native double getDistance()/*-{
 		return this.distance;
 	}-*/;
 

--- a/src/main/java/com/gwidgets/api/leaflet/events/TileErrorEvent.java
+++ b/src/main/java/com/gwidgets/api/leaflet/events/TileErrorEvent.java
@@ -34,7 +34,7 @@ public class TileErrorEvent extends Event {
 	 *
 	 * @return the tile
 	 */
-	public native HTMLElement getTile()/*-{
+	public final native HTMLElement getTile()/*-{
 		return this.tile;
 	}-*/;
 


### PR DESCRIPTION
Instance methods of non-final subclasses of JavaScriptObject should have a 'final' modifier otherwise 2.8.1 compiler complains about that.

> [INFO]    Tracing compile failure path for type 'com.gwidgets.api.leaflet.events.DragEndEvent'
[INFO]       [ERROR] Errors in 'jar:file:/C:/Users/corsair/.m2/repository/com/gwidgets/gwty-leaflet/0.5/gwty-leaflet-0.5.jar!/com/gwidgets/api/leaflet/events/DragEndEvent.java'
[INFO]          [ERROR] Line 34: Instance methods must be 'final' in non-final subclasses of JavaScriptObject
[INFO]    Tracing compile failure path for type 'com.gwidgets.api.leaflet.events.TileErrorEvent'
[INFO]       [ERROR] Errors in 'jar:file:/C:/Users/corsair/.m2/repository/com/gwidgets/gwty-leaflet/0.5/gwty-leaflet-0.5.jar!/com/gwidgets/api/leaflet/events/TileErrorEvent.java'
[INFO]          [ERROR] Line 37: Instance methods must be 'final' in non-final subclasses of JavaScriptObject
[INFO]    [ERROR] Aborting compile due to errors in some input files


