### PR TITLE
Update Elemental 2 dependency version to 1.0.0-beta-3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,17 +50,17 @@
         		<dependency>
 			<groupId>com.google.elemental2</groupId>
 			<artifactId>elemental2-core</artifactId>
-			<version>1.0.0-beta-1</version>
+			<version>1.0.0-beta-3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.elemental2</groupId>
 			<artifactId>elemental2-dom</artifactId>
-			<version>1.0.0-beta-1</version>
+			<version>1.0.0-beta-3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.elemental2</groupId>
 			<artifactId>elemental2-svg</artifactId>
-			<version>1.0.0-beta-1</version>
+			<version>1.0.0-beta-3</version>
 	  </dependency>
       <dependency>
 		<groupId>junit</groupId>

--- a/src/main/java/com/gwidgets/api/leaflet/utils/LeafletResources.java
+++ b/src/main/java/com/gwidgets/api/leaflet/utils/LeafletResources.java
@@ -3,13 +3,13 @@ package com.gwidgets.api.leaflet.utils;
 import com.google.gwt.core.client.GWT;
 
 import elemental2.dom.DomGlobal;
-import elemental2.dom.Element.OnloadCallbackFn;
+import elemental2.dom.Element.OnloadFn;
 import elemental2.dom.HTMLLinkElement;
 import elemental2.dom.HTMLScriptElement;
 
 
 public class LeafletResources {	
-	public static void whenReady(boolean debug, OnloadCallbackFn function){
+	public static void whenReady(boolean debug, OnloadFn function){
 		HTMLScriptElement leafletScript = (HTMLScriptElement) DomGlobal.document.createElement("script");
 		if (debug) {
 			leafletScript.src = GWT.getModuleName() + "/leaflet/leaflet-src.js";

--- a/src/test/java/com/gwidgets/leaflet/test/InjectedLeafletResources.java
+++ b/src/test/java/com/gwidgets/leaflet/test/InjectedLeafletResources.java
@@ -2,12 +2,12 @@ package com.gwidgets.leaflet.test;
 
 
 import elemental2.dom.DomGlobal;
-import elemental2.dom.Element.OnloadCallbackFn;
+import elemental2.dom.Element.OnloadFn;
 import elemental2.dom.HTMLLinkElement;
 import elemental2.dom.HTMLScriptElement;
 
 public class InjectedLeafletResources {
-public static void whenReady(OnloadCallbackFn function){		
+public static void whenReady(OnloadFn function){		
 		HTMLScriptElement leafletScript = (HTMLScriptElement) DomGlobal.document.createElement("script");
 		leafletScript.src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0/leaflet.js";
 		leafletScript.type="text/javascript";


### PR DESCRIPTION
- Updated Elemental 2 dependency version from 1.0.0-beta-1 to 1.0.0-beta-3
- Fixed breaking change from upstream: renamed `OnloadCallbackFn` references to `OnloadFn`